### PR TITLE
FIX: Actually fixing my last edits + Only publicly exposing useful methods

### DIFF
--- a/gtkutil/cssutil/cssutil.go
+++ b/gtkutil/cssutil/cssutil.go
@@ -73,7 +73,7 @@ func Applyf(widget gtk.Widgetter, f string, v ...interface{}) {
 
 // Apply applies the given CSS into the given widget's style context.
 func Apply(widget gtk.Widgetter, css string) {
-	prov := NewCSSProvFromString("<inline>", css)
+	prov := newCSSProvFromString("<inline>", css)
 	w := gtk.BaseWidget(widget)
 	s := w.StyleContext()
 	s.AddProvider(prov, gtk.STYLE_PROVIDER_PRIORITY_APPLICATION)
@@ -98,17 +98,22 @@ func AddClass(w gtk.Widgetter, classes ...string) {
 // ApplyGlobalCSS applies the current global CSS to the default display.
 func ApplyGlobalCSS() {
 	globalCSS := templateCSS("global", globalCSS.String())
-	prov := NewCSSProvFromString("<global>", globalCSS)
+	prov := newCSSProvFromString("<global>", globalCSS)
 	display := gdk.DisplayGetDefault()
 	gtk.StyleContextAddProviderForDisplay(display, prov, gtk.STYLE_PROVIDER_PRIORITY_APPLICATION)
 }
 
-// ApplyCSSProvider applies the provided provider to the default display.
-func ApplyCSSProvider(prov *gtk.CSSProvider) {
-	templatedCSS := templateCSS("provider", prov.String())
-	templatedProv := NewCSSProvFromString("<provider>", templatedCSS)
+// ApplyResourceCSS fetches the provided resource file, parses it through the templating engine and applies it to the default display.
+func ApplyResourceCSS(resourcePath string) {
+	// Create provider from resource
+	resProv := newCSSProvFromResource("<resource>", resourcePath)
+	// Apply the templating engine
+	templatedCSS := templateCSS("resource", resProv.String())
+	// Create the final provider
+	prov := newCSSProvFromString("<resource>", templatedCSS)
 	display := gdk.DisplayGetDefault()
-	gtk.StyleContextAddProviderForDisplay(display, templatedProv, gtk.STYLE_PROVIDER_PRIORITY_APPLICATION)
+	// Apply it to the default display
+	gtk.StyleContextAddProviderForDisplay(display, prov, gtk.STYLE_PROVIDER_PRIORITY_APPLICATION)
 }
 
 // ApplyUserCSS applies the user CSS at the given path.
@@ -134,7 +139,7 @@ func ApplyUserCSS(path string) {
 			"loading user.css",
 			"path", path)
 
-		prov := NewCSSProvFromString(path, userCSS)
+		prov := newCSSProvFromString(path, userCSS)
 
 		display := gdk.DisplayGetDefault()
 		// We use a higher priority than USER in order to override the user-
@@ -144,30 +149,27 @@ func ApplyUserCSS(path string) {
 	}
 }
 
-func newCSSProvider(file) *gtk.CSSProvider {
+func newCSSProvider(file string) *gtk.CSSProvider {
 	prov := gtk.NewCSSProvider()
 	prov.ConnectParsingError(func(sec *gtk.CSSSection, err error) {
-		loc := sec.StartLocation()
-		lines := strings.Split(css, "\n")
 		slog.Error(
 			"error parsing CSS",
 			"file", file,
-			"line", lines[loc.Lines()],
 			"err", err)
-		log.Printf("CSS error (%v) at line: %q", err, lines[loc.Lines()])
+		log.Printf("CSS error (%v) at line: %q", err)
 	})
 	return prov
 }
 
 // NewCSSProvFromString returns a CSSProvider object from a string
-func NewCSSProvFromString(file, css string) *gtk.CSSProvider {
+func newCSSProvFromString(file, css string) *gtk.CSSProvider {
 	prov := newCSSProvider(file)
 	prov.LoadFromString(css)
 	return prov
 }
 
 // NewCSSProvFromResource returns a CSSProvider object from a resource path
-func NewCSSProvFromResource(file, resourcePath string) *gtk.CSSProvider {
+func newCSSProvFromResource(file, resourcePath string) *gtk.CSSProvider {
 	prov := newCSSProvider(file)
 	prov.LoadFromResource(resourcePath)
 	return prov


### PR DESCRIPTION
This PR follows [the one that has been merged a bit too quickly](https://github.com/diamondburned/gotkit/pull/3)... :sweat_smile:

It fixes the following problems:

- Some function parameters were not typed
- NewCSSProvFromResource & NewCSSProvFromString are private again
- ApplyProviderCSS is now ApplyResourceCSS and do everything at once (instead of returning a gtk.CSSProvider)
